### PR TITLE
Fix invocation of iptables if redirection fails

### DIFF
--- a/internal/iptables/alternatives.go
+++ b/internal/iptables/alternatives.go
@@ -98,7 +98,7 @@ func (s symlinkSelector) UseMode(ctx context.Context, mode Mode) error {
 		_ = os.RemoveAll(cmdPath)
 
 		if err := os.Symlink(xtablesForModePath, cmdPath); err != nil {
-			return fmt.Errorf("creating %s symlink for mode %s: %v", cmd, modeStr, err)
+			return fmt.Errorf("creating %s symlink for mode %s: %w", cmd, modeStr, err)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path"
@@ -68,7 +69,13 @@ func main() {
 
 	selector := iptables.BuildAlternativeSelector(sbinPath)
 	if err := selector.UseMode(ctx, mode); err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?): %s\n", err)
+		// Ignore redirection error if target already exists. This may happen when
+		// multiple iptables-wrappers are racing each other or the filesystem is
+		// mounted read-only.
+		if !errors.Is(err, fs.ErrExist) {
+			fmt.Fprintf(os.Stderr, "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?): %s\n", err)
+		}
+
 		// fake it, though this will probably also fail if they aren't root
 		binaryPath = iptables.XtablesPath(sbinPath, mode)
 		args = os.Args

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 
 	"github.com/kubernetes-sigs/iptables-wrappers/internal/iptables"
 )
@@ -71,6 +72,7 @@ func main() {
 		// fake it, though this will probably also fail if they aren't root
 		binaryPath = iptables.XtablesPath(sbinPath, mode)
 		args = os.Args
+		args[0] = path.Base(args[0])
 	}
 
 	cmdIPTables := exec.CommandContext(ctx, binaryPath, args...)


### PR DESCRIPTION
Fix the invocation of iptables/nftables if the redirection fails. As os.Args[0] can still contain e.g. the full path of the symlink the wrapper was invoked as, the leading path components must be stripped for the actual iptables/nftables multi-call binary to know how to behave.

Also do not log an error if redirection failed because the target already exists. This can happen when multiple iptables-wrappers processes race each other, or the filesystem is mounted read-only (and removing the existing symlink silently failed). There is nothing to be done in these cases and the logs are just noise.