### PR TITLE
Fall back to command line when /proc is unavailable

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,7 +107,10 @@ func main() {
 func install(ctx context.Context) {
 	wrapperPath, err := os.Executable()
 	if err != nil {
-		fatal(err)
+		wrapperPath = os.Args[0]
+		if !filepath.IsAbs(wrapperPath) {
+			fatal(fmt.Errorf("needs a mounted proc filesystem (%w) or to be invoked via an absolute path (%q)", err, wrapperPath))
+		}
 	}
 	wrapperPath = filepath.Clean(wrapperPath)
 	installDir := filepath.Dir(wrapperPath)


### PR DESCRIPTION
The new install subcommand is using `os.Executable()`, which relies on the proc file system being available. That's not always the case when running in constrained environments, e.g. a chroot.

Fall back to the executable's command line whenever `os.Executable()` fails, and ensure that `iptables-wrapper` has been invoked via an absolute path.